### PR TITLE
[fix] Special characters in url getting escaped - Remove regex match feature

### DIFF
--- a/src/app/testexecutor.js
+++ b/src/app/testexecutor.js
@@ -425,17 +425,8 @@ const replaceVariablesInApi = (api, variables) => {
 			variables[variableAlias] = replacePlaceholderInString(api.variables[variableAlias], variables);
 		}
 	}
-
-	// escape url specific characters so that they are not replaced by regex string generator
-	['?', '$', '&', '(', ')'].forEach(char =>
-		api.url = api.url.split(char).join('\\' + char))
-
 	api.url = replacePlaceholderInString(api.url, variables);
 	api.payload = replacePlaceholderInString(api.payload, variables);
-
-	['?', '$', '&', '(', ')'].forEach(char =>
-		api.url = api.url.split(`\\${char}`).join(char))
-
 	return api;
 };
 


### PR DESCRIPTION
Issue : #27 

The purpose of this PR is to avoid unwanted escaping of the special characters in the `url` field and to remove the functionality of identifying and generating strings based on regex inside the url string. 